### PR TITLE
Cleaning up build outputs

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -50,7 +50,8 @@ goto :eof
 :: Package the output
 
 echo Packaging files
-call %~dp0\Tools\Nuget.exe pack %~dp0\pkg\OutputColorizer.nuspec -BasePath %~dp0\bin\release -OutputDirectory %~dp0\bin\
+if not exist "%~dp0\bin\package\" mkdir "%~dp0\bin\package\"
+call %~dp0\Tools\Nuget.exe pack %~dp0\pkg\OutputColorizer.nuspec -BasePath %~dp0\bin\release -OutputDirectory %~dp0\bin\package\
 echo.
 :: Pull the build summary from the log file
 findstr /ir /c:".*Warning(s)" /c:".*Error(s)" /c:"Time Elapsed.*" "%_buildlog%"

--- a/pkg/OutputColorizer.nuspec
+++ b/pkg/OutputColorizer.nuspec
@@ -20,6 +20,6 @@
     </metadata>
     <files>
         <file src="net45\OutputColorizer.dll" target="lib\net45" />
-        <file src="Core\OutputColorizer.dll" target="lib\netstandard1.5" />
+        <file src="..\OutputColorizer.Core\bin\Debug\netstandard1.5\OutputColorizer.dll" target="lib\netstandard1.5" />
     </files>
 </package>

--- a/src/OutputColorizer.Core/OutputColorizer.Core.xproj
+++ b/src/OutputColorizer.Core/OutputColorizer.Core.xproj
@@ -13,14 +13,22 @@
     <CLIPath>$(MSBuildThisFileDirectory)..\..\tools\dotnetcli\dotnet.exe</CLIPath>
     <ProjectJson>$(MSBuildThisFileDirectory)project.json</ProjectJson>
     <LockFile>$(MSBuildThisFileDirectory)project.lock.json</LockFile>
-    <OutputLocation>$(MSBuildThisFileDirectory)..\..\bin\Release\Core</OutputLocation>
+    <OutputLocation>$(MSBuildThisFileDirectory)..\..\bin\</OutputLocation>
   </PropertyGroup>
+
+  <Target Name="Rebuild" DependsOnTargets="Clean;Build" />
+
   <Target Name="Build" DependsOnTargets="Restore">
-    <Exec Command="$(CLIPath) build $(ProjectJson) -o $(OutputLocation) -f netstandard1.5" />
+    <Exec Command="$(CLIPath) build $(ProjectJson) -b $(OutputLocation) -f netstandard1.5" />
   </Target>
+
   <Target Name="Restore">
     <Error Condition="!Exists('$(CLIPath)')" Text="The cli is required to build this project. Please run init-tools.cmd command from the root of the repo to get it, and then build the solution again." />
     <Exec Command="$(CLIPath) restore $(ProjectJson)" />
     <Error Condition="!Exists('$(LockFile)')" Text="Error when running the restore." />
+  </Target>
+
+  <Target Name="Clean">
+    <RemoveDir Directories="$(OutputLocation)OutputColorizer.Core" Condition="Exists('$(OutputLocation)OutputColorizer.Core')" />
   </Target>
 </Project>

--- a/src/OutputColorizer.Tests/OutputColorizer.Tests.csproj
+++ b/src/OutputColorizer.Tests/OutputColorizer.Tests.csproj
@@ -16,13 +16,14 @@
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
     <IsCodedUITest>False</IsCodedUITest>
     <TestProjectType>UnitTest</TestProjectType>
+    <BaseIntermediateOutputPath>..\..\bin\obj\net45.Tests\</BaseIntermediateOutputPath>
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
+    <OutputPath>..\..\bin\Debug\net45.Tests\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -30,7 +31,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
+    <OutputPath>..\..\bin\Release\net45.Tests\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>

--- a/src/OutputColorizer/OutputColorizer.csproj
+++ b/src/OutputColorizer/OutputColorizer.csproj
@@ -11,6 +11,7 @@
     <AssemblyName>OutputColorizer</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <BaseIntermediateOutputPath>..\..\bin\obj\net45\</BaseIntermediateOutputPath>
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">


### PR DESCRIPTION
Wanted to do some cleanup on the build outputs. This will let you have your src folder clean from bin and obj dirs. Also it will enable rebuilds of the xproj.

CC: @AlexGhiondea 
