### PR TITLE
Add tests to increase the colorizer test coverage

### DIFF
--- a/src/OutputColorizer.Tests/Colorizer.Basic.Tests.cs
+++ b/src/OutputColorizer.Tests/Colorizer.Basic.Tests.cs
@@ -49,5 +49,14 @@ namespace UnitTests
             Validate(new TextAndColor(ConsoleColor.Green, "Foo"),
                 new TextAndColor(ConsoleColor.Black, " Test"));
         }
+
+        [TestMethod]
+        public void BasicTest6()
+        {
+            Colorizer.Write("[Green!Foo] Test");
+
+            Validate(new TextAndColor(ConsoleColor.Green, "Foo"),
+                new TextAndColor(ConsoleColor.Black, " Test"));
+        }
     }
 }

--- a/src/OutputColorizer.Tests/Colorizer.ErrorValidation.Tests.cs
+++ b/src/OutputColorizer.Tests/Colorizer.ErrorValidation.Tests.cs
@@ -33,5 +33,26 @@ namespace UnitTests
         {
             Colorizer.WriteLine("[Green!Test]]");
         }
+
+        [TestMethod]
+        [ExpectedException(typeof(FormatException))]
+        public void ErrorValidationTest5()
+        {
+            Colorizer.WriteLine("}");
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(FormatException))]
+        public void ErrorValidationTest6()
+        {
+            Colorizer.WriteLine("}}}");
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void ErrorValidationTest7()
+        {
+            Colorizer.WriteLine("{");
+        }
     }
 }

--- a/src/OutputColorizer.Tests/Colorizer.Escaping.Tests.cs
+++ b/src/OutputColorizer.Tests/Colorizer.Escaping.Tests.cs
@@ -72,5 +72,34 @@ namespace UnitTests
                 new TextAndColor(ConsoleColor.Green, "[Foo]"),
                 new TextAndColor(ConsoleColor.Black, "}"));
         }
+
+
+        [TestMethod]
+        public void EscapingTest8()
+        {
+            Colorizer.WriteLine("\"[Green!Foo]\"");
+
+            Validate(new TextAndColor(ConsoleColor.Black, "\""),
+                new TextAndColor(ConsoleColor.Green, "Foo"),
+                new TextAndColor(ConsoleColor.Black, "\""));
+        }
+
+        [TestMethod]
+        public void EscapingTest9()
+        {
+            Colorizer.WriteLine("}}[Green!Foo]{{");
+
+            Validate(new TextAndColor(ConsoleColor.Black, "}"),
+                new TextAndColor(ConsoleColor.Green, "Foo"),
+                new TextAndColor(ConsoleColor.Black, "{"));
+        }
+
+        [TestMethod]
+        public void EscapingTest10()
+        {
+            Colorizer.WriteLine("{{}}");
+
+            Validate(new TextAndColor(ConsoleColor.Black, "{}"));
+        }
     }
 }

--- a/src/OutputColorizer.Tests/Colorizer.Tests.cs
+++ b/src/OutputColorizer.Tests/Colorizer.Tests.cs
@@ -15,14 +15,14 @@ namespace UnitTests
             _printer = new TestWriter();
             Colorizer.SetupWriter(_printer);
         }
-        
+
         private void Validate(params TextAndColor[] values)
         {
-            Debug.Assert(values.Length == _printer.Segments.Count);
+            Assert.AreEqual(values.Length, _printer.Segments.Count);
 
             for (int i = 0; i < values.Length; i++)
             {
-                Debug.Assert(values[i].Equals(_printer.Segments[i]),
+                Assert.IsTrue(values[i].Equals(_printer.Segments[i]),
                     string.Format("Expected Text={0}, Color={1}, Got {2}", values[i].Text, values[i].Color, _printer.Segments[i]));
             }
         }

--- a/src/OutputColorizer/Colorizer.cs
+++ b/src/OutputColorizer/Colorizer.cs
@@ -183,7 +183,7 @@ namespace OutputColorizer
                 if (content[pos] == '{')
                 {
                     // '{' are escaped as '{{'
-                    if (pos + 1 < textLength && content[pos + 1] == '{')
+                    if (content[pos + 1] == '{')
                     {
                         sb.Append('{'); sb.Append('{');
                         pos++;
@@ -191,7 +191,7 @@ namespace OutputColorizer
                     }
 
                     int temp = pos;
-                    while (temp < textLength && content[temp++] != '}')
+                    while (content[temp++] != '}')
                     {
                     }
 


### PR DESCRIPTION
Remove unnecessary code when rewriting the string as we already handle that validation when creating the argument map.
